### PR TITLE
Fix: Update git clone command to use HTTPS in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ cargo install --locked cargo-leptos
 
 ```sh
 # you will be prompted to enter project name
-cargo generate --git git@github.com:codeitlikemiley/tauri-leptos-ssr
+cargo generate --git https://github.com/codeitlikemiley/tauri-leptos-ssr.git
 # or with cargo leptos
-cargo leptos new --git git@github.com:codeitlikemiley/tauri-leptos-ssr
+cargo leptos new --git https://github.com/codeitlikemiley/tauri-leptos-ssr.git
 
 # example output:
 # you will be prompted for project name


### PR DESCRIPTION
The git clone commands in README.md were using SSH format, which can lead to "Error: Please check if the Git user / repository exists." if SSH keys are not properly configured or if HTTPS is the expected method. This commit updates them to use HTTPS format for broader compatibility and ease of use.